### PR TITLE
Rename opps variable to opportunities

### DIFF
--- a/tests/test_arbitrage_detector.py
+++ b/tests/test_arbitrage_detector.py
@@ -10,8 +10,8 @@ def test_detect_opportunity_simple():
         }
     }
     detector = ArbitrageDetector()
-    opps = detector.detect_opportunity(prices)
-    assert len(opps) > 0
-    assert opps[0]['buy_venue'] == 'binance'
-    assert opps[0]['sell_venue'] == 'aerodrome'
-    assert opps[0]['pair'] == 'RIZE/USDT' 
+    opportunities = detector.detect_opportunity(prices)
+    assert len(opportunities) > 0
+    assert opportunities[0]['buy_venue'] == 'binance'
+    assert opportunities[0]['sell_venue'] == 'aerodrome'
+    assert opportunities[0]['pair'] == 'RIZE/USDT'


### PR DESCRIPTION
## Summary
- clarify variable name in arbitrage detector test

## Testing
- `PYTHONPATH=. pytest tests/test_arbitrage_detector.py`

------
https://chatgpt.com/codex/tasks/task_e_688f711a67108321bbd12624316db5e3